### PR TITLE
chore: updated extension title

### DIFF
--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Default Popup Title</title>
+    <title>Plex Screenshot Helper</title>
     <meta name="manifest.type" content="browser_action" />
   </head>
   <body>


### PR DESCRIPTION
I just noticed that when hovering on the extension icon, it shows as `Default Popup Title` XD

<img width="224" alt="image" src="https://github.com/user-attachments/assets/6948bb46-01e3-4b84-bb22-6f0a615c1b13" />
